### PR TITLE
Remove a unused import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 extern crate rustc_serialize;
 
-use std::thread;
 use std::process::Command;
 use rustc_serialize::json::Json;
 


### PR DESCRIPTION
cargo build said:

```
warning: unused import: `std::thread`, #[warn(unused_imports)] on by default
 --> src/main.rs:4:5
  |
4 | use std::thread;
  |     ^^^^^^^^^^^
```